### PR TITLE
Added small sleep to vary server startup to avoid port contention

### DIFF
--- a/lib/stripe_checkout_mock/bootable.rb
+++ b/lib/stripe_checkout_mock/bootable.rb
@@ -23,6 +23,7 @@ module StripeCheckoutMock
     end
 
     def find_available_port
+      SleepUtil.short_random_sleep
       server = TCPServer.new(0)
       server.addr[1]
     ensure

--- a/lib/stripe_checkout_mock/sleep_util.rb
+++ b/lib/stripe_checkout_mock/sleep_util.rb
@@ -1,0 +1,5 @@
+module SleepUtil
+  def self.short_random_sleep
+    sleep(rand(0.01..0.099))
+  end
+end

--- a/spec/stripe_checkout_mock/sleep_util_spec.rb
+++ b/spec/stripe_checkout_mock/sleep_util_spec.rb
@@ -1,0 +1,22 @@
+require_relative "../spec_helper"
+require "stripe_checkout_mock/sleep_util"
+
+RSpec.describe SleepUtil do
+  it "should sleep" do
+    time_start = Time.now
+
+    described_class.short_random_sleep
+
+    time_end = Time.now
+    expect(time_end - time_start).to be > 0
+  end
+
+  it "sleep should be very short" do
+    time_start = Time.now
+
+    described_class.short_random_sleep
+
+    time_end = Time.now
+    expect(time_end - time_start).to be <= 0.1
+  end
+end


### PR DESCRIPTION
This adds a *very small* sleep so to avoid port contention when the multiple test servers spin up.